### PR TITLE
CI: Temporary fix for picotool fetching develop branch.

### DIFF
--- a/ci/micropython.sh
+++ b/ci/micropython.sh
@@ -43,6 +43,11 @@ function ci_micropython_clone {
     git submodule update --init lib/micropython-lib
     git submodule update --init lib/tinyusb
     git submodule update --init lib/btstack
+
+    # HACK: Fix SDK 2.1.1 being pinned at the "develop" picotool branch :|
+    cd "$CI_BUILD_ROOT/micropython/lib/pico-sdk" || return 1
+    git apply "$CI_PROJECT_ROOT/ci/picotool-2.1.1.patch"
+
     cd "$CI_BUILD_ROOT"
 }
 

--- a/ci/picotool-2.1.1.patch
+++ b/ci/picotool-2.1.1.patch
@@ -1,0 +1,23 @@
+From 9a4113fbbae65ee82d8cd6537963bc3d3b14bcca Mon Sep 17 00:00:00 2001
+From: will-v-pi <108662275+will-v-pi@users.noreply.github.com>
+Date: Mon, 7 Jul 2025 16:33:58 +0100
+Subject: [PATCH] Lock picotool version on master to 2.1.1 (#2401)
+
+The master SDK branch (and the SDK release tags eg 2.1.1) should point to specific picotool tags, to ensure you get a compatible picotool (note this is beyond the 2.1.1 tag in master, so will just fix this for users who check out the HEAD of master)
+---
+ tools/Findpicotool.cmake | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tools/Findpicotool.cmake b/tools/Findpicotool.cmake
+index e5bfaeaac..4720a79f0 100644
+--- a/tools/Findpicotool.cmake
++++ b/tools/Findpicotool.cmake
+@@ -37,7 +37,7 @@ if (NOT TARGET picotool)
+         message("Downloading Picotool")
+         FetchContent_Populate(picotool QUIET
+             GIT_REPOSITORY https://github.com/raspberrypi/picotool.git
+-            GIT_TAG develop
++            GIT_TAG 2.1.1
+ 
+             SOURCE_DIR ${picotool_INSTALL_DIR}/picotool-src
+             BINARY_DIR ${picotool_INSTALL_DIR}/picotool-build


### PR DESCRIPTION
Pico SDK 2.1.1 was released referencing the develop branch of picotool, which was later fixed in a commit post 2.1.1 and only available on the master branch.

This change vendors the upstream patch against master and backports it to the 2.1.1 tree in MicroPython. This is a fragile, temporary fix to get this build out of the door- it *will* break when MicroPython bump Pico SDK.

TODO: Investigate fetching and installing picotool standalone.

See:

https://github.com/raspberrypi/picotool/issues/256