### PR TITLE
Examples: use external led for PWM example

### DIFF
--- a/examples/led_pulse.py
+++ b/examples/led_pulse.py
@@ -1,14 +1,11 @@
-from machine import Pin, PWM
+from machine import PWM
 import time
 import math
 
-PULSE_PERIOD = 5 # Seconds
+PULSE_PERIOD = 5   # Seconds
 
-# Set up the LED as an output
-Pin.board.LED.init(mode=Pin.OUT)
-
-# Set up PWM on our LED pin
-led = PWM(Pin.board.LED)
+# Set up PWM on our LED pin. We're using Pin 22 in this example.
+led = PWM(22)
 
 # 1000Hz frequency
 led.freq(1000)


### PR DESCRIPTION
Resolves issue raised in #3. 

Due to the onboard LED on the XL W being connected to a GPIO on the RM2, it is not possible to PWM it. To maintain compatibility across all boards, I have opted to change this example to use an external LED.