### PR TITLE
CI: Retarget to rebased RM2 changes.

### DIFF
--- a/ci/micropython.sh
+++ b/ci/micropython.sh
@@ -1,7 +1,7 @@
 export TERM=${TERM:="xterm-256color"}
 
 MICROPYTHON_FLAVOUR="pimoroni"
-MICROPYTHON_VERSION="pico2_w_2025_04_09"
+MICROPYTHON_VERSION="pico2_w_2025_07_21"
 
 PIMORONI_PICO_FLAVOUR="pimoroni"
 PIMORONI_PICO_VERSION="feature/picovector2-and-layers"


### PR DESCRIPTION
Our experimental branch (had a couple of additional patches) may have been causing issues writing to the filesystem. This switches to the latest rebase of the RM2 support branch which seems to work reliably for me.

Note: This sweeps up a bunch of additional fixes/changes in MicroPython since v1.25